### PR TITLE
MAJOR Update action to run on Node 16 instead of Node 12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'github-action-runtime/index.js'


### PR DESCRIPTION
Referred to https://github.com/UnlyEd/github-action-store-variable/issues/38